### PR TITLE
Added support for dynamic binding of spi device in spidev.

### DIFF
--- a/arch/arm/mach-bcm2708/bcm2708.c
+++ b/arch/arm/mach-bcm2708/bcm2708.c
@@ -500,6 +500,9 @@ static struct platform_device bcm2708_spi_device = {
 	.resource = bcm2708_spi_resources,
 };
 
+/*
+ * Do not link the spi device by default to spidev, since now spidev support manual binding.
+
 static struct spi_board_info bcm2708_spi_devices[] = {
 	{
 		.modalias = "spidev",
@@ -515,6 +518,7 @@ static struct spi_board_info bcm2708_spi_devices[] = {
 		.mode = SPI_MODE_0,
 	}
 };
+*/
 
 static struct resource bcm2708_bsc0_resources[] = {
 	{

--- a/arch/arm/mach-bcm2708/bcm2708.c
+++ b/arch/arm/mach-bcm2708/bcm2708.c
@@ -629,8 +629,8 @@ void __init bcm2708_init(void)
 	system_serial_low = serial;
 
 #ifdef CONFIG_SPI
-	spi_register_board_info(bcm2708_spi_devices,
-			ARRAY_SIZE(bcm2708_spi_devices));
+#	spi_register_board_info(bcm2708_spi_devices,
+#			ARRAY_SIZE(bcm2708_spi_devices));
 #endif
 }
 

--- a/arch/arm/mach-bcm2708/bcm2708.c
+++ b/arch/arm/mach-bcm2708/bcm2708.c
@@ -629,8 +629,8 @@ void __init bcm2708_init(void)
 	system_serial_low = serial;
 
 #ifdef CONFIG_SPI
-#	spi_register_board_info(bcm2708_spi_devices,
-#			ARRAY_SIZE(bcm2708_spi_devices));
+//	spi_register_board_info(bcm2708_spi_devices,
+//			ARRAY_SIZE(bcm2708_spi_devices));
 #endif
 }
 


### PR DESCRIPTION
This patches does two things :
- Remove the spi_board_info from bcm2708.c which by default are linked to spidev in this version of the kernel.
- Add dynamic binding to spidev allowing to choose at runtime which spi device is linked to the spidev driver

This feature is really usefull, because during the development of a spi driver it allows to swtich from the spidev or the currently develloped drvier without rebuilding the kernel and even without rebooting
